### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Flask RESTify
 
 [![Build Status](https://travis-ci.org/cllu/Flask-RESTify.svg?branch=master)](https://travis-ci.org/cllu/Flask-RESTify)
-[![Latest Version](https://pypip.in/version/Flask-RESTify/badge.svg)](https://pypi.python.org/pypi/Flask-RESTify/)
+[![Latest Version](https://img.shields.io/pypi/v/Flask-RESTify.svg)](https://pypi.python.org/pypi/Flask-RESTify/)
 [![Dependency Status](https://gemnasium.com/cllu/Flask-RESTify.svg)](https://gemnasium.com/cllu/Flask-RESTify)
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flask-restify))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flask-restify`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.